### PR TITLE
Config in declare clippy lint

### DIFF
--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -1,5 +1,6 @@
 //! lint on enum variants that are prefixed or suffixed by the same characters
 
+use crate::Conf;
 use clippy_utils::diagnostics::{span_lint, span_lint_and_help};
 use clippy_utils::source::is_present_in_source;
 use clippy_utils::str_utils::{camel_case_split, count_match_end, count_match_start};
@@ -112,11 +113,13 @@ pub struct EnumVariantNames {
 
 impl EnumVariantNames {
     #[must_use]
-    pub fn new(threshold: u64, avoid_breaking_exported_api: bool) -> Self {
+    pub fn new() -> Self {
+        dbg!(ENUM_VARIANT_NAMES_SUPPORTED_CONFIG());
+
         Self {
             modules: Vec::new(),
-            threshold,
-            avoid_breaking_exported_api,
+            threshold: Conf::instance().enum_variant_name_threshold(),
+            avoid_breaking_exported_api: Conf::instance().avoid_breaking_exported_api(),
         }
     }
 }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -313,7 +313,7 @@ mod zero_sized_map_values;
 // end lints modules, do not remove this comment, it’s used in `update_lints`
 
 use crate::utils::conf::{format_error, TryConf};
-pub use crate::utils::conf::{lookup_conf_file, Conf};
+pub use crate::utils::conf::{lookup_conf_file, Conf, CONF_INSTANCE};
 
 /// Register all pre expansion lints
 ///

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -748,13 +748,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
             literal_representation_threshold,
         ))
     });
-    let enum_variant_name_threshold = conf.enum_variant_name_threshold;
-    store.register_late_pass(move |_| {
-        Box::new(enum_variants::EnumVariantNames::new(
-            enum_variant_name_threshold,
-            avoid_breaking_exported_api,
-        ))
-    });
+    store.register_late_pass(move |_| Box::new(enum_variants::EnumVariantNames::new()));
     store.register_early_pass(|| Box::new(tabs_in_doc_comments::TabsInDocComments));
     let upper_case_acronyms_aggressive = conf.upper_case_acronyms_aggressive;
     store.register_late_pass(move |_| {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -150,6 +150,9 @@ impl rustc_driver::Callbacks for ClippyCallbacks {
             }
 
             let conf = clippy_lints::read_conf(sess, &conf_path);
+            clippy_lints::CONF_INSTANCE
+                .set(conf.clone())
+                .expect("failed to instantiate Conf");
             clippy_lints::register_plugins(lint_store, sess, &conf);
             clippy_lints::register_pre_expansion_lints(lint_store, sess, &conf);
             clippy_lints::register_renamed(lint_store);


### PR DESCRIPTION
Prototyping config store

I'll try to implement validation logic in ways:
https://github.com/koka831/rust-clippy/pull/1/files#diff-1d884fd439e15a9e47e1135cdc0ab5ee896a876b9f4c256ecce4be6c69a8831dR123-R132

related zulip: https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Some.20lints.20miss.20its.20config

## TODO

- [ ] try plan A
- [x] try plan B
- [ ] try plan C, lint if config is defined propery (config key will be unified with the config store, so it might be possible to check it, like comparing `get_lints()` and `define_Conf` keys)
- [ ] create an issue for (proposal|retrospective) of this challenge